### PR TITLE
Fixed building in newer versions of VS

### DIFF
--- a/src/Analyzers/MSHack2022.Analyzers.csproj
+++ b/src/Analyzers/MSHack2022.Analyzers.csproj
@@ -9,7 +9,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4-beta1.22403.2" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0-1.final" />
 	</ItemGroup>
 </Project>

--- a/src/Codefixers/MSHack2022.Codefixers.csproj
+++ b/src/Codefixers/MSHack2022.Codefixers.csproj
@@ -8,7 +8,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.3.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4-beta1.22403.2" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0-1.final" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Package/MSHack2022.Package.csproj
+++ b/src/Package/MSHack2022.Package.csproj
@@ -21,6 +21,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4-beta1.22403.2" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<ProjectReference Include="..\Analyzers\MSHack2022.Analyzers.csproj" />
 		<ProjectReference Include="..\Codefixers\MSHack2022.Codefixers.csproj" />
 	</ItemGroup>

--- a/tests/MSHack2022.Tests.csproj
+++ b/tests/MSHack2022.Tests.csproj
@@ -7,7 +7,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis" Version="4.3.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis" Version="4.4.0-1.final" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4-beta1.22403.2" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.1" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.1" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.XUnit" Version="1.1.1" />


### PR DESCRIPTION
Now using a preview version of `Microsoft.CodeAnalysis` that works in the newest versions of VS.