### PR TITLE
Add VS extension proj for debug

### DIFF
--- a/mshack2022.sln
+++ b/mshack2022.sln
@@ -17,7 +17,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebSample", "samples\WebSam
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MSHack2022.Tests", "tests\MSHack2022.Tests.csproj", "{D4B5340C-DB22-4D93-A631-C265583E0261}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorSample", "samples\BlazorSample\BlazorSample.csproj", "{63BD1A26-29ED-48AF-A646-06F9D74DD13F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorSample", "samples\BlazorSample\BlazorSample.csproj", "{63BD1A26-29ED-48AF-A646-06F9D74DD13F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MSHack2022.Vsix", "src\Vsix\MSHack2022.Vsix.csproj", "{7BB3B46B-7984-4755-8BBB-591FCADADFD0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -49,6 +51,10 @@ Global
 		{63BD1A26-29ED-48AF-A646-06F9D74DD13F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{63BD1A26-29ED-48AF-A646-06F9D74DD13F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{63BD1A26-29ED-48AF-A646-06F9D74DD13F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7BB3B46B-7984-4755-8BBB-591FCADADFD0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7BB3B46B-7984-4755-8BBB-591FCADADFD0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7BB3B46B-7984-4755-8BBB-591FCADADFD0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7BB3B46B-7984-4755-8BBB-591FCADADFD0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -59,6 +65,7 @@ Global
 		{84A98762-6D93-44B8-B02D-9CA94763453D} = {4D043F42-F942-4CD8-AD50-99755F44DCCE}
 		{CC1176B2-0644-4013-82DA-37A6B8DA0CE8} = {73E56F0C-E6DE-4162-8610-5CD6ACB21958}
 		{63BD1A26-29ED-48AF-A646-06F9D74DD13F} = {73E56F0C-E6DE-4162-8610-5CD6ACB21958}
+		{7BB3B46B-7984-4755-8BBB-591FCADADFD0} = {4D043F42-F942-4CD8-AD50-99755F44DCCE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B03A45E7-049F-4BEA-A98F-5F3E9A572036}

--- a/src/Vsix/MSHack2022.Vsix.csproj
+++ b/src/Vsix/MSHack2022.Vsix.csproj
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <RootNamespace>MSHack2022.Vsix</RootNamespace>
+    <AssemblyName>MSHack2022.Vsix</AssemblyName>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GeneratePkgDefFile>false</GeneratePkgDefFile>
+    <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
+    <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
+    <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
+    <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
+    <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
+    <VSSDKTargetPlatformRegRootSuffix>Roslyn</VSSDKTargetPlatformRegRootSuffix>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.32112.339" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.4.1092-preview2" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <StartAction>Program</StartAction>
+    <StartProgram>$(DevEnvDir)devenv.exe</StartProgram>
+    <StartArguments>/rootsuffix $(VSSDKTargetPlatformRegRootSuffix)</StartArguments>
+  </PropertyGroup>
+
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
+
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="Exists('$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets')" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\Analyzers\MSHack2022.Analyzers.csproj" />
+    <ProjectReference Include="..\Codefixers\MSHack2022.Codefixers.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- https://github.com/dotnet/sdk/issues/433 -->
+    <ProjectReference Update="@(ProjectReference)" AdditionalProperties="TargetFramework=netstandard2.0" />
+
+    <!-- https://github.com/Microsoft/extendvs/issues/57 -->
+    <ProjectReference Update="@(ProjectReference)" Name="%(Filename)" />
+  </ItemGroup>
+
+</Project>

--- a/src/Vsix/source.extension.vsixmanifest
+++ b/src/Vsix/source.extension.vsixmanifest
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
+  <Metadata>
+    <Identity Id="MSHack2022.Vsix.efb82023-a06d-48bb-a5d4-f8795d49a7c6" Version="1.0" Language="en-US" Publisher="Francesco Bonacci" />
+    <DisplayName>MSHack2022.Vsix</DisplayName>
+    <Description>Empty VSIX Project.</Description>
+  </Metadata>
+  <Installation>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+  </Installation>
+  <Dependencies>
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+  </Dependencies>
+  <Prerequisites>
+  	<Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,18.0)" DisplayName="Visual Studio core editor" />
+  	<Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.LanguageServices" Version="[17.0,18.0)" DisplayName="Roslyn Language Services" />
+  </Prerequisites>
+  <Assets>
+	  <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="MSHack2022.Analyzers" Path="|MSHack2022.Analyzers|"/>
+	  <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="MSHack2022.Analyzers" Path="|MSHack2022.Analyzers|"/>
+	  <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="MSHack2022.CodeFixers" Path="|MSHack2022.CodeFixers|"/>
+	  <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="MSHack2022.CodeFixers" Path="|MSHack2022.CodeFixers|"/>
+  </Assets>
+</PackageManifest>


### PR DESCRIPTION
To make debugging sessions easier and not rely on `Debug.Fail`, we can set `MSHack2022.Vsix` as startup proj and debug a new instance of VS instead.

My two cents: this way we could move the samples projs to another solution.

Tested with latest VS preview and SDK 7.0.100-rc.1.